### PR TITLE
chore: remove defers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -78,6 +78,7 @@ class SMFOperatorCharm(CharmBase):
         self._certificates = TLSCertificatesRequiresV3(self, "certificates")
 
         self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.update_status, self._configure_sdcore_smf)
         self.framework.observe(self.on.smf_pebble_ready, self._configure_sdcore_smf)
         self.framework.observe(self.on.database_relation_joined, self._configure_sdcore_smf)
         self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,11 +105,9 @@ class SMFOperatorCharm(CharmBase):
         """
         if not self._container.can_connect():
             self.unit.status = WaitingStatus("Waiting for container to be ready")
-            event.defer()
             return
         if not self._storage_is_attached():
             self.unit.status = WaitingStatus("Waiting for storage to be attached")
-            event.defer()
             return
         self._write_ue_config_file()
 
@@ -146,7 +144,6 @@ class SMFOperatorCharm(CharmBase):
             return
         if not self._storage_is_attached():
             self.unit.status = WaitingStatus("Waiting for storage to be attached")
-            event.defer()
             return
         if not _get_pod_ip():
             self.unit.status = WaitingStatus("Waiting for pod IP address to be available")

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -32,7 +32,7 @@ configuration:
     - nsmf-oam
   pfcp:
     addr: 1.1.1.1
-  nrfUri: http://nrf.com:8080
+  nrfUri: https://nrf:443
 
 # the kind of log output
 # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic


### PR DESCRIPTION
# Description

This PR aims to remove `defer` statements from the main configuration callback.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
