### PR TITLE
chore: Cetralize status management

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -173,7 +173,7 @@ async def test_when_scale_app_beyond_1_then_only_one_unit_is_active(
     await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_at_least_units=3)
     unit_statuses = Counter(unit.workload_status for unit in app.units)
     assert unit_statuses.get("active") == 1
-    assert unit_statuses.get("blocked") == 2
+    assert unit_statuses.get("unknown") == 2
 
 
 async def test_remove_app(ops_test: OpsTest, build_and_deploy):


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm. Event named collect_unit_status sets the status of charm automatically at the end of every hook.

Reference:

    - https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
    - https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
