### PR TITLE
fix: remove unnecessary callback when relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -82,11 +82,9 @@ class SMFOperatorCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._configure_sdcore_smf)
         self.framework.observe(self.on.smf_pebble_ready, self._configure_sdcore_smf)
         self.framework.observe(self.on.database_relation_joined, self._configure_sdcore_smf)
-        self.framework.observe(self.on.database_relation_broken, self._configure_sdcore_smf)
         self.framework.observe(self._database.on.database_created, self._configure_sdcore_smf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_sdcore_smf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_sdcore_smf)
-        self.framework.observe(self._nrf_requires.on.nrf_broken, self._configure_sdcore_smf)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_sdcore_smf)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken


### PR DESCRIPTION
# Description

In case of `nrf broken` or `db relation broken` event, the call to _configure_smf returns immediately due to the missing relation and does not perform any configuration.
It can be removed.
Blocked status is automatically set by the collect unit status event.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
