### PR TITLE
fix: Use same track for developer charm

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
     with:
       branch-name: ${{ github.ref_name }}
       charm-file-name: "sdcore-smf-k8s_ubuntu-22.04-amd64.charm"
-      track-name: 1.3
+      track-name: 1.4
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 


### PR DESCRIPTION
# Description

Wrong track was still in the developer charm publish step.
