### PR TITLE
chore: use Pytest

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -47,7 +47,7 @@ LOGGING_RELATION_NAME = "logging"
 
 
 class SMFOperatorCharm(CharmBase):
-    """Charm the service."""
+    """Main class to describe juju event handling for the SD-Core SMF operator for K8s."""
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -96,6 +96,45 @@ class SMFOperatorCharm(CharmBase):
         self.framework.observe(
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
+
+    def _configure_sdcore_smf(self, event: EventBase) -> None:  # noqa C901
+        """Configure the Pebble layer for Juju events.
+
+        Whenever a Juju event is emitted, this method performs a couple of checks to make sure that
+        the workload is ready to be started. Then, it configures the Webui workload,
+        and runs the Pebble services.
+
+        Args:
+            event (EventBase): Juju event
+        """
+        if not self.ready_to_configure():
+            logger.info("The preconditions for the configuration are not met yet.")
+            return
+
+        if not self._ue_config_file_is_written():
+            self._write_ue_config_file()
+
+        if not self._private_key_is_stored():
+            self._generate_private_key()
+
+        if not self._csr_is_stored():
+            self._request_new_certificate()
+
+        provider_certificate = self._get_current_provider_certificate()
+        if not provider_certificate:
+            return
+
+        if certificate_update_required := self._is_certificate_update_required(
+            provider_certificate
+        ):
+            self._store_certificate(certificate=provider_certificate)
+
+        desired_config_file = self._generate_smf_config_file()
+        if config_update_required := self._is_config_update_required(desired_config_file):
+            self._push_config_file(content=desired_config_file)
+
+        should_restart = config_update_required or certificate_update_required
+        self._configure_pebble(restart=should_restart)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
@@ -196,41 +235,6 @@ class SMFOperatorCharm(CharmBase):
             return False
 
         return True
-
-    def _configure_sdcore_smf(self, event: EventBase) -> None:  # noqa C901
-        """Add pebble layer and manages Juju unit status.
-
-        Args:
-            event: Juju event
-        """
-        if not self.ready_to_configure():
-            logger.info("The preconditions for the configuration are not met yet.")
-            return
-
-        if not self._ue_config_file_is_written():
-            self._write_ue_config_file()
-
-        if not self._private_key_is_stored():
-            self._generate_private_key()
-
-        if not self._csr_is_stored():
-            self._request_new_certificate()
-
-        provider_certificate = self._get_current_provider_certificate()
-        if not provider_certificate:
-            return
-
-        if certificate_update_required := self._is_certificate_update_required(
-            provider_certificate
-        ):
-            self._store_certificate(certificate=provider_certificate)
-
-        desired_config_file = self._generate_smf_config_file()
-        if config_update_required := self._is_config_update_required(desired_config_file):
-            self._push_config_file(content=desired_config_file)
-
-        should_restart = config_update_required or certificate_update_required
-        self._configure_pebble(restart=should_restart)
 
     def _push_config_file(
         self,
@@ -407,7 +411,11 @@ class SMFOperatorCharm(CharmBase):
         logger.info("Pushed CSR to workload")
 
     def _configure_pebble(self, restart=False) -> None:
-        """Configure the Pebble layer.
+        """Configure and restart the workload if required.
+
+        This method detects the changes between the Pebble layer and the Pebble services.
+        If a change is detected, it applies the desired configuration.
+        Then, it restarts the workload if a restart is required.
 
         Args:
             restart (bool): Whether to restart the SMF container.
@@ -446,12 +454,9 @@ class SMFOperatorCharm(CharmBase):
         return bool(self.model.get_relation(relation_name))
 
     def _storage_is_attached(self) -> bool:
-        """Return whether storage is attached to the workload container.
-
-        Returns:
-            bool: Whether storage is attached.
-        """
-        return self._container.exists(path=BASE_CONFIG_PATH)
+        return self._container.exists(path=BASE_CONFIG_PATH) and self._container.exists(
+            path=CERTS_DIR_PATH
+        )
 
     def _config_file_is_written(self) -> bool:
         """Return whether the config file was written to the workload container.

--- a/src/charm.py
+++ b/src/charm.py
@@ -101,7 +101,7 @@ class SMFOperatorCharm(CharmBase):
         """Configure the Pebble layer for Juju events.
 
         Whenever a Juju event is emitted, this method performs a couple of checks to make sure that
-        the workload is ready to be started. Then, it configures the Webui workload,
+        the workload is ready to be started. Then, it configures the SMF workload,
         and runs the Pebble services.
 
         Args:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,9 +2,10 @@
 # See LICENSE file for licensing details.
 
 import logging
-import unittest
+from typing import Generator
 from unittest.mock import Mock, PropertyMock, patch
 
+import pytest
 import yaml
 from charm import SMFOperatorCharm
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
@@ -15,36 +16,89 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
+DATABASE_URL = "http://6.5.6.5"
+DATABASE_USERNAME = "rock"
+DATABASE_PASSWORD = "paper"
+DB_APPLICATION_NAME = "mongodb-k8s"
+DB_RELATION_NAME = "database"
+NRF_APPLICATION_NAME = "nrf"
+NRF_RELATION_NAME = "fiveg_nrf"
+TLS_APPLICATION_NAME = "tls-certificates-operator"
+TLS_RELATION_NAME = "certificates"
+NAMESPACE = "whatever"
 POD_IP = b"1.1.1.1"
 VALID_NRF_URL = "https://nrf:443"
 CERTIFICATES_LIB = (
     "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3"
 )
 CERTIFICATE = "whatever certificate content"
+CERTIFICATE_PATH = "support/TLS/smf.pem"
 CSR = "whatever CSR content"
+CSR_PATH = "support/TLS/smf.csr"
 PRIVATE_KEY = "whatever key content"
+PRIVATE_KEY_PATH = "support/TLS/smf.key"
+CONFIG_FILE_PATH = "etc/smf/smfcfg.yaml"
+EXPECTED_CONFIG_FILE_PATH = "tests/unit/expected_smfcfg.yaml"
+UE_CONFIG_FILE_PATH = "etc/smf/uerouting.yaml"
+EXPECTED_UE_CONFIG_FILE_PATH = "src/uerouting.yaml"
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.maxDiff = None
-        self.namespace = "whatever"
-        self.database_application_name = "mongodb-k8s"
-        self.metadata = self._get_metadata()
-        self.container_name = list(self.metadata["containers"].keys())[0]
+class TestCharm:
+
+    patcher_check_output = patch("charm.check_output")
+    patcher_nrf_url = patch(
+        "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url",
+        new_callable=PropertyMock
+    )
+    patcher_is_resource_created = patch(
+        "charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created"
+    )
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_assigned_certificates = patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")  # noqa: E501
+    patcher_request_certificate_creation = patch(f"{CERTIFICATES_LIB}.request_certificate_creation")  # noqa: E501
+
+    @pytest.fixture()
+    def setup(self):
+        self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
+        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
+        self.mock_get_assigned_certificates = TestCharm.patcher_get_assigned_certificates.start()
+        self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
+        self.mock_is_resource_created = TestCharm.patcher_is_resource_created.start()
+        self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        metadata = self._get_metadata()
+        self.container_name = list(metadata["containers"].keys())[0]
+
+    @staticmethod
+    def teardown() -> None:
+        patch.stopall()
+
+    @pytest.fixture()
+    def mock_default_values(self):
+        self.mock_nrf_url.return_value = VALID_NRF_URL
+        self.mock_check_output.return_value = POD_IP
+        self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setup, request):
         self.harness = testing.Harness(SMFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.teardown)
+
+    @pytest.fixture()
+    def add_storage(self) -> None:
+        self.harness.add_storage(storage_name="certs", attach=True)  # type:ignore
+        self.harness.add_storage(storage_name="config", attach=True)  # type:ignore
 
     @staticmethod
     def _get_metadata() -> dict:
-        """Read `charmcraft.yaml` and returns it as a dictionary.
-
-        Returns:
-            dics: charmcraft.yaml as a dictionary.
-        """
+        """Read `charmcraft.yaml` and returns it as a dictionary."""
         with open("charmcraft.yaml", "r") as f:
             data = yaml.safe_load(f)
         return data
@@ -61,431 +115,287 @@ class TestCharm(unittest.TestCase):
         """
         with open(path, "r") as f:
             content = f.read()
-
         return content
 
-    def _create_database_relation(self) -> int:
-        """Create SMF database relation.
+    @staticmethod
+    def _get_provider_certificate():
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR
+        return provider_certificate
 
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
-            relation_name="database", remote_app=self.database_application_name
-        )
-        self.harness.add_relation_unit(
-            relation_id=relation_id, remote_unit_name=f"{self.database_application_name}/0"
-        )
-        return relation_id
+    @pytest.fixture()
+    def nrf_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(  # type:ignore
 
-    def _create_nrf_relation(self) -> int:
-        """Create NRF relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
-            relation_name="fiveg_nrf", remote_app="nrf-operator"
+            relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
         )
-        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")
-        return relation_id
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")  # type:ignore
+        yield relation_id
+
+    @pytest.fixture()
+    def certificates_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.add_relation_unit(  # type:ignore
+            relation_id=relation_id, remote_unit_name="tls-certificates-operator/0"
+        )
+        yield relation_id
+
+    @pytest.fixture()
+    def database_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=DB_RELATION_NAME,
+            remote_app=DB_APPLICATION_NAME,
+        )
+        self.harness.add_relation_unit(  # type:ignore
+            relation_id=relation_id,
+            remote_unit_name=f"{DB_APPLICATION_NAME}/0",
+        )
+        yield relation_id
 
     def _create_database_relation_and_populate_data(self) -> int:
-        database_url = "http://6.5.6.5"
-        database_username = "rock"
-        database_password = "paper"
-        database_relation_id = self._create_database_relation()
-        self.harness.update_relation_data(
+        """Create a database relation and set the database information.
+
+        Returns:
+            relation_id: ID of the created relation
+        """
+        database_relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=DB_RELATION_NAME,
+            remote_app=DB_APPLICATION_NAME,
+        )
+        self.harness.update_relation_data(  # type:ignore
             relation_id=database_relation_id,
-            app_or_unit=self.database_application_name,
+            app_or_unit=DB_APPLICATION_NAME,
             key_values={
-                "username": database_username,
-                "password": database_password,
-                "uris": "".join([database_url]),
+                "username": DATABASE_USERNAME,
+                "password": DATABASE_PASSWORD,
+                "uris": "".join([DATABASE_URL]),
             },
         )
         return database_relation_id
 
-    def _create_certificates_relation(self) -> int:
-        """Create certificates relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
-            relation_name="certificates", remote_app="tls-certificates-operator"
-        )
-        self.harness.add_relation_unit(
-            relation_id=relation_id, remote_unit_name="tls-certificates-operator/0"
-        )
-        return relation_id
-
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
     def test_given_container_can_connect_and_storage_is_attached_when_configure_sdcore_smf_is_called_then_ue_config_file_is_written_to_workload_container(  # noqa: E501
-        self, patch_check_output, patch_nrf_url
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self.harness.add_storage("certs", attach=True)
-        self.harness.add_storage("config", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        self._create_certificates_relation()
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
 
-        expected_config_file_content = self._read_file("src/uerouting.yaml")
+        expected_config_file_content = self._read_file(EXPECTED_UE_CONFIG_FILE_PATH)
 
-        self.assertEqual(
-            (root / "etc/smf/uerouting.yaml").read_text(), expected_config_file_content
-        )
+        assert (root / UE_CONFIG_FILE_PATH).read_text() == expected_config_file_content
 
     def test_given_database_relation_not_created_when_configure_sdcore_smf_is_called_then_status_is_blocked(  # noqa: E501
         self,
     ):
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
     def test_given_nrf_relation_not_created_when_configure_sdcore_smf_is_called_then_status_is_blocked(  # noqa: E501
-        self,
+        self, database_relation_id
     ):
-        self._create_database_relation()
-
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
     def test_given_certificates_relation_not_created_when_configure_sdcore_smf_is_called_then_status_is_blocked(  # noqa: E501
-        self,
+        self, nrf_relation_id, database_relation_id
     ):
-        self._create_database_relation()
-        self._create_nrf_relation()
-
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for certificates relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
     def test_given_smf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
-        self, patch_check_output, patch_nrf_url
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
-        self.harness.add_storage("certs", attach=True)
         certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.pem").write_text(certificate)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
+        (root / CERTIFICATE_PATH).write_text(certificate)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self._create_database_relation_and_populate_data()
-        nrf_relation_id = self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(nrf_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
     def test_given_smf_charm_in_active_status_when_database_relation_breaks_then_status_is_blocked(
-        self, patch_check_output, patch_nrf_url
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
-        self.harness.add_storage("certs", attach=True)
         certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.pem").write_text(certificate)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
+        (root / CERTIFICATE_PATH).write_text(certificate)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         database_relation_id = self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(database_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
     def test_given_container_cant_connect_when_configure_sdcore_smf_is_called_is_called_then_status_is_waiting(  # noqa: E501
-        self,
+        self, nrf_relation_id, database_relation_id, certificates_relation_id
     ):
-        self._create_database_relation()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=False)
-
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_database_relation_not_available_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self,
+        add_storage,
+        mock_default_values,
+        nrf_relation_id,
+        certificates_relation_id,
+        database_relation_id
     ):
-        self._create_database_relation()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=True)
-
+        self.mock_is_resource_created.return_value = False
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for `database` relation to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for `database` relation to be available")  # noqa: E501
 
     def test_given_nrf_is_not_available_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self,
+        add_storage,
+        nrf_relation_id,
+        certificates_relation_id
     ):
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=True)
-
+        self.mock_nrf_url.return_value = None
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for NRF relation to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF relation to be available")  # noqa: E501
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    def test_given_storage_is_not_attached_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
-        self, patch_nrf_url
+    @pytest.mark.parametrize(
+        "storage_name",
+        [
+            "certs",
+            "config",
+        ]
+    )
+    def test_config_storage_is_not_attached_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
+        self, nrf_relation_id, certificates_relation_id, storage_name
     ):
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.add_storage(storage_name=storage_name, attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for storage to be attached"),
-        )
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
+
     def test_given_ip_not_available_when_configure_then_status_is_waiting(
-        self,
-        patch_check_output,
-        patch_nrf_url,
+        self, add_storage, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.charm._certificate_is_stored = Mock(return_value=True)
-        patch_check_output.return_value = b""
-        patch_nrf_url.return_value = VALID_NRF_URL
+        self.mock_check_output.return_value = b""
 
         self.harness.container_pebble_ready(container_name=self.container_name)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for pod IP address to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_certificate_is_not_stored_when_configure_sdcore_smf_then_status_is_waiting(  # noqa: E501
-        self,
-        patch_nrf_url,
-        patch_check_output,
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
-        self.harness.add_storage("certs", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        patch_check_output.return_value = POD_IP
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.charm._storage_is_attached = Mock(return_value=True)
         self.harness.charm._ue_config_file_is_written = Mock(return_value=True)
         self.harness.charm._certificate_is_stored = Mock(return_value=False)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_status_is_active(  # noqa: E501
-        self, _, patched_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
+        self.mock_get_assigned_certificates.return_value = [self._get_provider_certificate()]
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         pod_ip = "1.1.1.1"
-        patch_check_output.return_value = pod_ip.encode()
+        self.mock_check_output.return_value = pod_ip.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
         self._create_database_relation_and_populate_data()
-        self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        assert self.harness.model.unit.status == ActiveStatus()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_nrf_is_available_when_database_is_created_then_config_file_is_written_with_expected_content(  # noqa: E501
-        self, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
-        self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [self._get_provider_certificate()]
 
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
 
-        self.assertEqual(
-            (root / "etc/smf/smfcfg.yaml").read_text(),
-            self._read_file("tests/unit/expected_smfcfg.yaml"),
-        )
+        assert (root / CONFIG_FILE_PATH).read_text() == self._read_file(EXPECTED_CONFIG_FILE_PATH)
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_config_file_exists_and_is_not_changed_when_configure_smf_then_config_file_is_not_re_written_with_same_content(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_nrf_url,
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage("config", attach=True)
-        self.harness.add_storage("certs", attach=True)
         certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.pem").write_text(certificate)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        (root / "etc/smf/smfcfg.yaml").write_text(
-            self._read_file("tests/unit/expected_smfcfg.yaml")
+        (root / CERTIFICATE_PATH).write_text(certificate)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
+        (root / CONFIG_FILE_PATH).write_text(
+            self._read_file(EXPECTED_CONFIG_FILE_PATH)
         )
-        config_modification_time = (root / "etc/smf/smfcfg.yaml").stat().st_mtime
+        config_modification_time = (root / CONFIG_FILE_PATH).stat().st_mtime
         pod_ip = "1.1.1.1"
-        patch_check_output.return_value = pod_ip.encode()
-        patch_nrf_url.return_value = VALID_NRF_URL
+        self.mock_check_output.return_value = pod_ip.encode()
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
 
-        self.assertEqual((root / "etc/smf/smfcfg.yaml").stat().st_mtime, config_modification_time)
+        assert (root / CONFIG_FILE_PATH).stat().st_mtime == config_modification_time
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_config_file_exists_and_is_changed_when_configure_smf_then_config_file_is_updated(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_nrf_url,
-        patch_get_assigned_certificates,
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        (root / "etc/smf/smfcfg.yaml").write_text("super different config file content")
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
+        (root / CSR_PATH).write_text(CSR)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
+        (root / CONFIG_FILE_PATH).write_text("super different config file content")
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [self._get_provider_certificate()]
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.container_pebble_ready(self.container_name)
 
-        self.assertEqual(
-            (root / "etc/smf/smfcfg.yaml").read_text(),
-            self._read_file("tests/unit/expected_smfcfg.yaml"),
-        )
+        assert (root / CONFIG_FILE_PATH).read_text() == self._read_file(EXPECTED_CONFIG_FILE_PATH)
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_expected_plan_is_applied(  # noqa: E501
-        self, patch_check_output, patch_nrf_url, patch_get_assigned_certificates
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
+
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-
+        self.mock_get_assigned_certificates.return_value = [self._get_provider_certificate()]
         self.harness.set_can_connect(container=self.container_name, val=True)
-
         self.harness.container_pebble_ready(self.container_name)
 
         expected_plan = {
@@ -508,211 +418,138 @@ class TestCharm(unittest.TestCase):
             },
         }
         updated_plan = self.harness.get_container_pebble_plan(self.container_name).to_dict()
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
     def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
-        self,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_nrf_url,
+        self, add_storage, mock_default_values, nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_generate_private_key.return_value = PRIVATE_KEY.encode()
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
         csr = CSR.encode()
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = csr
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
-        self.assertEqual((root / "support/TLS/smf.key").read_text(), PRIVATE_KEY)
+        assert (root / PRIVATE_KEY_PATH).read_text() == PRIVATE_KEY
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
         self,
     ):
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
 
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/smf.key").read_text()
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/smf.pem").read_text()
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/smf.csr").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / PRIVATE_KEY_PATH).read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / CERTIFICATE_PATH).read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / CSR_PATH).read_text()
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation", new=Mock)
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, patch_check_output, patch_generate_csr, patched_nrf_url
+        self, add_storage, nrf_relation_id, certificates_relation_id, mock_default_values
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
+
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        patch_generate_csr.return_value = CSR.encode()
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
 
-        self.assertEqual((root / "support/TLS/smf.csr").read_text(), CSR)
+        assert (root / CSR_PATH).read_text() == CSR
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_and_cert_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_generate_csr,
-        patched_nrf_url,
-        patch_request_certificate_creation,
+        self, add_storage, nrf_relation_id, certificates_relation_id, mock_default_values
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        patch_generate_csr.return_value = CSR.encode()
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self.harness.set_can_connect(container=self.container_name, val=True)
-
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
 
-        patch_request_certificate_creation.assert_called_with(
+        self.mock_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()
         )
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_cert_already_stored_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
-        self, patch_check_output, patched_nrf_url, patch_request_certificate_creation
+        self, add_storage, mock_default_values
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage, nrf_relation_id, certificates_relation_id, mock_default_values
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        (root / "etc/smf/uerouting.yaml").write_text(self._read_file("src/uerouting.yaml"))
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
+        (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
         self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self._create_certificates_relation()
 
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [self._get_provider_certificate()]
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.container_pebble_ready(self.container_name)
 
-        self.assertEqual((root / "support/TLS/smf.pem").read_text(), CERTIFICATE)
+        assert (root / CERTIFICATE_PATH).read_text() == CERTIFICATE
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage, nrf_relation_id, certificates_relation_id, mock_default_values
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
+
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "support/TLS/smf.csr").write_text(CSR)
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = CERTIFICATE
         provider_certificate.csr = "Relation CSR content (different from stored one)"
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
         self.harness.container_pebble_ready(self.container_name)
 
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/smf.pem").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / CERTIFICATE_PATH).read_text()
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charm.generate_csr")
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self,
     ):
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
         certificate = "Stored certificate content"
-        (root / "support/TLS/smf.pem").write_text(certificate)
+        (root / CERTIFICATE_PATH).write_text(certificate)
         event = Mock()
         event.certificate = "Relation certificate content (different from stored)"
         csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = csr
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charm.generate_csr")
     def test_given_certificate_matches_stored_one_when_certificate_expiring_then_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/smf.key").write_text(PRIVATE_KEY)
-        (root / "support/TLS/smf.pem").write_text(CERTIFICATE)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         event = Mock()
         event.certificate = CERTIFICATE
-        patch_generate_csr.return_value = CSR.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_called_with(
+        self.mock_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()
         )


### PR DESCRIPTION
# Description

Use only pytest framework to run the unit tests.

- Add a @pytest.fixture for harness
- Add a @pytest.fixture to setup patches and mocks
- Continue using Mock, call and patch from the unittest.Mock library
- Add a parameterized test using @pytest.mark.parametrize
- Use assert instead of self.assert
- Modify docstring of `configure_sdcore_smf` method  and place this method just after constructor
- Check the existence of CERTS_DIR_PATH  under `_storage_is_attached` method

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
