### PR TITLE
feat: adding workload version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -169,19 +169,19 @@ class SMFOperatorCharm(CharmBase):
             logger.info("Scaling is not implemented for this charm")
             return
 
-        if not self._container.can_connect():
-            event.add_status(WaitingStatus("Waiting for container to be ready"))
-            logger.info("Waiting for container to be ready")
-            return
-
-        self.unit.set_workload_version(self._get_workload_version())
-
         if missing_relations := self._missing_relations():
             event.add_status(
                 BlockedStatus(f"Waiting for {', '.join(missing_relations)} relation(s)")
             )
             logger.info("Waiting for %s  relation(s)", ", ".join(missing_relations))
             return
+
+        if not self._container.can_connect():
+            event.add_status(WaitingStatus("Waiting for container to be ready"))
+            logger.info("Waiting for container to be ready")
+            return
+
+        self.unit.set_workload_version(self._get_workload_version())
 
         if not self._database_is_available():
             event.add_status(WaitingStatus("Waiting for `database` relation to be available"))

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,6 @@
 
 """Charmed operator for the 5G SMF service for K8s."""
 
-
 import logging
 from ipaddress import IPv4Address
 from subprocess import check_output
@@ -51,6 +50,7 @@ FIVEG_NRF_RELATION_NAME = "fiveg_nrf"
 SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
 TLS_RELATION_NAME = "certificates"
 DATABASE_RELATION_NAME = "database"
+WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
 
 
 class SMFOperatorCharm(CharmBase):
@@ -155,6 +155,7 @@ class SMFOperatorCharm(CharmBase):
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
 
+        Also sets the unit workload version if present
         Args:
             event: CollectStatusEvent
         """
@@ -168,16 +169,18 @@ class SMFOperatorCharm(CharmBase):
             logger.info("Scaling is not implemented for this charm")
             return
 
+        if not self._container.can_connect():
+            event.add_status(WaitingStatus("Waiting for container to be ready"))
+            logger.info("Waiting for container to be ready")
+            return
+
+        self.unit.set_workload_version(self._get_workload_version())
+
         if missing_relations := self._missing_relations():
             event.add_status(
                 BlockedStatus(f"Waiting for {', '.join(missing_relations)} relation(s)")
             )
-            logger.info("Waiting for %s  relation(s)", ', '.join(missing_relations))
-            return
-
-        if not self._container.can_connect():
-            event.add_status(WaitingStatus("Waiting for container to be ready"))
-            logger.info("Waiting for container to be ready")
+            logger.info("Waiting for %s  relation(s)", ", ".join(missing_relations))
             return
 
         if not self._database_is_available():
@@ -269,10 +272,12 @@ class SMFOperatorCharm(CharmBase):
             list: missing relation names.
         """
         missing_relations = []
-        for relation in [FIVEG_NRF_RELATION_NAME,
-                         DATABASE_RELATION_NAME,
-                         TLS_RELATION_NAME,
-                         SDCORE_CONFIG_RELATION_NAME]:
+        for relation in [
+            FIVEG_NRF_RELATION_NAME,
+            DATABASE_RELATION_NAME,
+            TLS_RELATION_NAME,
+            SDCORE_CONFIG_RELATION_NAME,
+        ]:
             if not self._relation_created(relation):
                 missing_relations.append(relation)
         return missing_relations
@@ -456,6 +461,24 @@ class SMFOperatorCharm(CharmBase):
         self._container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
 
+    def _get_workload_version(self) -> str:
+        """Return the workload version.
+
+        Checks for the presence of /etc/workload-version file
+        and if present, returns the contents of that file. If
+        the file is not present, an empty string is returned.
+
+        Returns:
+            string: A human readable string representing the
+            version of the workload
+        """
+        if self._container.exists(path=f"{WORKLOAD_VERSION_FILE_NAME}"):
+            version_file_content = self._container.pull(
+                path=f"{WORKLOAD_VERSION_FILE_NAME}"
+            ).read()
+            return version_file_content
+        return ""
+
     def _configure_pebble(self, restart=False) -> None:
         """Configure and restart the workload if required.
 
@@ -468,9 +491,7 @@ class SMFOperatorCharm(CharmBase):
         """
         plan = self._container.get_plan()
         if plan.services != self._pebble_layer.services:
-            self._container.add_layer(
-                self._container_name, self._pebble_layer, combine=True
-            )
+            self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
             self._container.replan()
             logger.info("New layer added: %s", self._pebble_layer)
         if restart:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -697,7 +697,11 @@ class TestCharm:
 
     def test_given_no_workload_version_file_when_container_can_connect_then_workload_version_not_set(  # noqa: E501
         self,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready(container_name=self.container_name)
         self.harness.evaluate_status()
         version = self.harness.get_workload_version()
@@ -705,7 +709,11 @@ class TestCharm:
 
     def test_given_workload_version_file_when_container_can_connect_then_workload_version_set(
         self,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
+        self._create_database_relation_and_populate_data()
         expected_version = "1.2.3"
         root = self.harness.get_filesystem_root(self.container_name)
         os.mkdir(f"{root}/etc")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import os
 from typing import Generator
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -46,15 +47,13 @@ EXPECTED_UE_CONFIG_FILE_PATH = "src/uerouting.yaml"
 
 
 class TestCharm:
-
     patcher_check_output = patch("charm.check_output")
     patcher_nrf_url = patch(
-        "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url",
-        new_callable=PropertyMock
+        "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock
     )
     patcher_webui_url = patch(
         "charms.sdcore_webui_k8s.v0.sdcore_config.SdcoreConfigRequires.webui_url",
-        new_callable=PropertyMock
+        new_callable=PropertyMock,
     )
     patcher_is_resource_created = patch(
         "charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created"
@@ -62,14 +61,18 @@ class TestCharm:
     patcher_generate_csr = patch("charm.generate_csr")
     patcher_generate_private_key = patch("charm.generate_private_key")
     patcher_get_assigned_certificates = patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")  # noqa: E501
-    patcher_request_certificate_creation = patch(f"{CERTIFICATES_LIB}.request_certificate_creation")  # noqa: E501
+    patcher_request_certificate_creation = patch(
+        f"{CERTIFICATES_LIB}.request_certificate_creation"
+    )  # noqa: E501
 
     @pytest.fixture()
     def setup(self):
         self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
         self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
         self.mock_get_assigned_certificates = TestCharm.patcher_get_assigned_certificates.start()
-        self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
+        self.mock_request_certificate_creation = (
+            TestCharm.patcher_request_certificate_creation.start()
+        )  # noqa: E501
         self.mock_is_resource_created = TestCharm.patcher_is_resource_created.start()
         self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
         self.mock_webui_url = TestCharm.patcher_webui_url.start()
@@ -135,7 +138,6 @@ class TestCharm:
     @pytest.fixture()
     def nrf_relation_id(self) -> Generator[int, None, None]:
         relation_id = self.harness.add_relation(  # type:ignore
-
             relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
         )
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")  # type:ignore
@@ -258,7 +260,7 @@ class TestCharm:
         mock_default_values,
         nrf_relation_id,
         certificates_relation_id,
-        sdcore_config_relation_id
+        sdcore_config_relation_id,
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
@@ -347,7 +349,9 @@ class TestCharm:
         self.mock_nrf_url.return_value = None
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF relation to be available")  # noqa: E501
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for NRF relation to be available"
+        )  # noqa: E501
 
     def test_given_webui_data_not_available_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self,
@@ -362,14 +366,16 @@ class TestCharm:
         self.mock_webui_url.return_value = None
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for Webui data to be available")  # noqa: E501
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for Webui data to be available"
+        )  # noqa: E501
 
     @pytest.mark.parametrize(
         "storage_name",
         [
             "certs",
             "config",
-        ]
+        ],
     )
     def test_storage_is_not_attached_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self, nrf_relation_id, certificates_relation_id, storage_name, sdcore_config_relation_id
@@ -380,7 +386,9 @@ class TestCharm:
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for storage to be attached"
+        )  # noqa: E501
 
     def test_given_ip_not_available_when_configure_then_status_is_waiting(
         self, add_storage, nrf_relation_id, certificates_relation_id, sdcore_config_relation_id
@@ -391,7 +399,9 @@ class TestCharm:
 
         self.harness.container_pebble_ready(container_name=self.container_name)
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for pod IP address to be available"
+        )  # noqa: E501
 
     def test_given_certificate_is_not_stored_when_configure_sdcore_smf_then_status_is_waiting(  # noqa: E501
         self,
@@ -409,7 +419,9 @@ class TestCharm:
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for certificates to be stored"
+        )  # noqa: E501
 
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_status_is_active(  # noqa: E501
         self,
@@ -462,9 +474,7 @@ class TestCharm:
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
-        (root / CONFIG_FILE_PATH).write_text(
-            self._read_file(EXPECTED_CONFIG_FILE_PATH)
-        )
+        (root / CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_CONFIG_FILE_PATH))
         config_modification_time = (root / CONFIG_FILE_PATH).stat().st_mtime
         self._create_database_relation_and_populate_data()
         self.harness.set_can_connect(container=self.container_name, val=True)
@@ -574,7 +584,6 @@ class TestCharm:
         mock_default_values,
         sdcore_config_relation_id,
     ):
-
         root = self.harness.get_filesystem_root(self.container_name)
         (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
         (root / UE_CONFIG_FILE_PATH).write_text(self._read_file(EXPECTED_UE_CONFIG_FILE_PATH))
@@ -685,3 +694,23 @@ class TestCharm:
         self.mock_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()
         )
+
+    def test_given_no_workload_version_file_when_container_can_connect_then_workload_version_not_set(  # noqa: E501
+        self,
+    ):
+        self.harness.container_pebble_ready(container_name=self.container_name)
+        self.harness.evaluate_status()
+        version = self.harness.get_workload_version()
+        assert version == ""
+
+    def test_given_workload_version_file_when_container_can_connect_then_workload_version_set(
+        self,
+    ):
+        expected_version = "1.2.3"
+        root = self.harness.get_filesystem_root(self.container_name)
+        os.mkdir(f"{root}/etc")
+        (root / "etc/workload-version").write_text(expected_version)
+        self.harness.container_pebble_ready(container_name=self.container_name)
+        self.harness.evaluate_status()
+        version = self.harness.get_workload_version()
+        assert version == expected_version


### PR DESCRIPTION
# Description

Checks the running container for a specific /etc/workload-version file. If it exists, the content of that file is reported in the app version field. 

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
