### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio==0.21.2
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,25 +12,29 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +43,23 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
@@ -59,7 +69,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -70,12 +82,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
@@ -85,7 +94,9 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
@@ -102,7 +113,9 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -116,10 +129,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -135,10 +149,9 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -150,7 +163,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -169,6 +182,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -181,7 +195,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import SMFOperatorCharm
 
@@ -39,6 +39,6 @@ class SMFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=SMFOperatorCharm,
         )

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import SMFUnitTestFixtures
 
@@ -14,18 +14,18 @@ class TestCharmCertificatesRelationBroken(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -38,7 +38,7 @@ class TestCharmCertificatesRelationBroken(SMFUnitTestFixtures):
             with open(f"{tempdir}/smf.key", "w") as f:
                 f.write("private key")
 
-            state_in = scenario.State(
+            state_in = testing.State(
                 relations=[certificates_relation],
                 containers=[container],
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -3,8 +3,7 @@
 
 import tempfile
 
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.certificates_helpers import example_cert_and_key
@@ -15,14 +14,14 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_fiveg_nrf_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[certificates_relation, sdcore_config_relation],
@@ -35,12 +34,12 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_certificates_relation_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        sdcore_config_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[nrf_relation, sdcore_config_relation],
@@ -53,12 +52,12 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_sdcore_config_relation_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[nrf_relation, certificates_relation],
@@ -71,15 +70,15 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_nrf_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[
@@ -97,15 +96,15 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_webui_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[
@@ -124,15 +123,15 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[
@@ -151,25 +150,25 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -191,22 +190,22 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            sdcore_config_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf",
                 can_connect=True,
                 mounts={
@@ -214,7 +213,7 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
                     "certs": certs_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -239,29 +238,29 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf",
                 layers={"smf": Layer({"services": {}})},
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
                 service_statuses={"smf": ServiceStatus.INACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -285,22 +284,22 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf",
                 layers={
                     "smf": Layer(
@@ -328,7 +327,7 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
                 mounts={"certs": certs_mount, "config": config_mount},
                 service_statuses={"smf": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -351,15 +350,15 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
     def test_given_no_workload_version_file_when_collect_unit_status_then_workload_version_not_set(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="smf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[
@@ -377,24 +376,24 @@ class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
             expected_version = "1.2.3"
             with open(f"{tempdir}/workload-version", "w") as f:
                 f.write(expected_version)
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import example_cert_and_key
@@ -16,25 +16,25 @@ class TestCharmConfigure(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -42,7 +42,7 @@ class TestCharmConfigure(SMFUnitTestFixtures):
                     certificates_relation,
                     sdcore_config_relation,
                 ],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             self.mock_check_output.return_value = b"1.1.1.1"
             provider_certificate, private_key = example_cert_and_key(
@@ -69,25 +69,25 @@ class TestCharmConfigure(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -95,7 +95,7 @@ class TestCharmConfigure(SMFUnitTestFixtures):
                     certificates_relation,
                     sdcore_config_relation,
                 ],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             self.mock_check_output.return_value = b"1.1.1.1"
             provider_certificate, private_key = example_cert_and_key(
@@ -118,25 +118,25 @@ class TestCharmConfigure(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/smf",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[
@@ -182,28 +182,28 @@ class TestCharmConfigure(SMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="smf",
                 can_connect=True,
                 mounts={
-                    "certs": scenario.Mount(
+                    "certs": testing.Mount(
                         location="/support/TLS",
                         source=tempdir,
                     ),
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/smf",
                         source=tempdir,
                     ),
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[
                     nrf_relation,


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
