### PR TITLE
feat: add NMS integration with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ juju deploy self-signed-certificates
 juju deploy sdcore-nms-k8s --channel=1.5/edge
 juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
 juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-smf-k8s:default-database mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:sdcore_config sdcore-nms-k8s:sdcore_config

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,6 +49,8 @@ async def _deploy_nrf(ops_test: OpsTest):
         channel=NRF_APP_CHANNEL,
         trust=True,
     )
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
 
 
 async def _deploy_tls_provider(ops_test: OpsTest):
@@ -78,6 +80,13 @@ async def _deploy_nms(ops_test: OpsTest):
         application_name=NMS_CHARM_NAME,
         channel=NMS_CHARM_CHANNEL,
     )
+    await ops_test.model.integrate(
+        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(
+        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_PROVIDER_APP_NAME)
 
 
 @pytest.fixture(scope="module")
@@ -95,21 +104,13 @@ async def deploy(ops_test: OpsTest, request):
         trust=True,
     )
     await _deploy_database(ops_test)
-    await _deploy_nrf(ops_test)
     await _deploy_tls_provider(ops_test)
     await _deploy_nms(ops_test)
+    await _deploy_nrf(ops_test)
     await _deploy_grafana_agent(ops_test)
     await ops_test.model.integrate(
         relation1=f"{NRF_APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
 
 
 @pytest.mark.abort_on_fail
@@ -156,8 +157,6 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy)
     await ops_test.model.integrate(
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
@@ -174,6 +173,8 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_tls_provider(ops_test)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 
@@ -188,12 +189,6 @@ async def test_remove_nms_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 async def test_restore_nms_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
     await _deploy_nms(ops_test)
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
-    )
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:sdcore_config", relation2=f"{NMS_CHARM_NAME}:sdcore_config"
     )


### PR DESCRIPTION
# Description

This PR adds the NMS integration with the TLS to the integration tests.
TLS certificates integration is mandatory for NMS and the NMS charm does not share the webui address until this relation exists.
This PR remove some duplication

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
