### PR TITLE
feat: add log-level configuration option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,3 +66,10 @@ parts:
       rustup default stable
       uv export --frozen --no-dev -o requirements.txt
       craftctl default
+
+config:
+  options:
+    log-level:
+      type: string
+      default: info
+      description: Log level for the SMF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -34,29 +34,6 @@ configuration:
     addr: {{ pod_ip }}
   nrfUri: {{ nrf_url }}
 
-# the kind of log output
-# debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-# ReportCaller: enable the caller report or not, value: true or false
 logger:
   SMF:
-    debugLevel: info
-    ReportCaller: false
-  NAS:
-    debugLevel: info
-    ReportCaller: false
-  NGAP:
-    debugLevel: info
-    ReportCaller: false
-  Aper:
-    debugLevel: info
-    ReportCaller: false
-  PathUtil:
-    debugLevel: info
-    ReportCaller: false
-  OpenApi:
-    debugLevel: info
-    ReportCaller: false
-  PFCP:
-    debugLevel: info
-    ReportCaller: false
-
+    debugLevel: {{ log_level }}

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -34,28 +34,6 @@ configuration:
     addr: 1.1.1.1
   nrfUri: https://nrf:443
 
-# the kind of log output
-# debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-# ReportCaller: enable the caller report or not, value: true or false
 logger:
   SMF:
     debugLevel: info
-    ReportCaller: false
-  NAS:
-    debugLevel: info
-    ReportCaller: false
-  NGAP:
-    debugLevel: info
-    ReportCaller: false
-  Aper:
-    debugLevel: info
-    ReportCaller: false
-  PathUtil:
-    debugLevel: info
-    ReportCaller: false
-  OpenApi:
-    debugLevel: info
-    ReportCaller: false
-  PFCP:
-    debugLevel: info
-    ReportCaller: false

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -11,6 +11,22 @@ from tests.unit.fixtures import SMFUnitTestFixtures
 
 
 class TestCharmCollectUnitStatus(SMFUnitTestFixtures):
+    def test_given_invalid_log_level_config_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        container = testing.Container(name="smf", can_connect=True)
+        state_in = testing.State(
+            leader=True,
+            config={"log-level": "invalid"},
+            containers={container},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "The following configurations are not valid: ['log-level']"
+        )
+
     def test_given_fiveg_nrf_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):


### PR DESCRIPTION
# Description

Here we add a `log-level` configuration option with a reasonable default value (`info`). The allowed options are the same as in the workload: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

## Rationale

In most deployments, the log level should be set to `info` to ensure the log quantity is reasonable. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
